### PR TITLE
Checked resolve

### DIFF
--- a/fuzz/fuzz_targets/checked_resolve.rs
+++ b/fuzz/fuzz_targets/checked_resolve.rs
@@ -1,0 +1,31 @@
+#![no_main]
+use fluent_uri::Uri;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: (&str, &str)| {
+    let (Ok(base), Ok(r)) = (Uri::parse(data.0), Uri::parse(data.1)) else {
+        return;
+    };
+
+    let Ok(u1) = r.checked_resolve(&base) else { return };
+    let u2 = Uri::parse(u1.as_str()).unwrap();
+
+    assert_eq!(
+        u1.scheme().map(|s| s.as_str()),
+        u2.scheme().map(|s| s.as_str())
+    );
+    assert_eq!(u1.authority().is_some(), u2.authority().is_some());
+
+    if let Some(a1) = u1.authority() {
+        let a2 = u2.authority().unwrap();
+        assert_eq!(a1.as_str(), a2.as_str());
+        assert_eq!(a1.userinfo(), a2.userinfo());
+        assert_eq!(a1.host(), a2.host());
+        assert_eq!(a1.host_parsed(), a2.host_parsed());
+        assert_eq!(a1.port(), a2.port());
+    }
+
+    assert_eq!(u1.path(), u2.path());
+    assert_eq!(u1.query(), u2.query());
+    assert_eq!(u1.fragment(), u2.fragment());
+});

--- a/src/error.rs
+++ b/src/error.rs
@@ -60,15 +60,15 @@ impl<I> std::error::Error for ParseError<I> {}
 
 /// Detailed cause of a [`ResolveError`].
 #[derive(Clone, Copy, Debug)]
-pub(crate) enum ResolveErrorKind {
+pub enum ResolveErrorKind {
     NonAbsoluteBase,
     NonHierarchicalBase,
-    // PathUnderflow,
+    PathUnderflow,
 }
 
 /// An error occurred when resolving URI references.
 #[derive(Clone, Copy, Debug)]
-pub struct ResolveError(pub(crate) ResolveErrorKind);
+pub struct ResolveError(pub ResolveErrorKind);
 
 #[cfg(feature = "std")]
 impl std::error::Error for ResolveError {}

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -58,6 +58,9 @@ impl Display for ResolveError {
             ResolveErrorKind::NonHierarchicalBase => {
                 "resolving non-same-document relative reference against non-hierarchical base URI"
             }
+            ResolveErrorKind::PathUnderflow => {
+                "resolve underflow"
+            }
         };
         f.write_str(msg)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -422,7 +422,27 @@ impl<'i, 'o, T: BorrowOrShare<'i, 'o, str>> Uri<T> {
     /// # Ok::<_, Box<fluent_uri::error::ParseError>>(())
     /// ```
     pub fn normalize(&self) -> Uri<String> {
-        normalizer::normalize(self.into())
+        normalizer::normalize(self.into(), false).ok().unwrap()
+    }
+
+    /// Normalizes the URI reference.
+    ///
+    /// This method applies the syntax-based normalization described in
+    /// [Section 6.2.2 of RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986/#section-6.2.2).
+    ///
+    /// TODO: Expand the doc.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use fluent_uri::Uri;
+    ///
+    /// let uri = Uri::parse("eXAMPLE://a/./b/../b/%63/%7bfoo%7d")?;
+    /// assert_eq!(uri.normalize_checked().ok().unwrap(), "example://a/b/c/%7Bfoo%7D");
+    /// # Ok::<_, Box<fluent_uri::error::ParseError>>(())
+    /// ```
+    pub fn normalize_checked(&self) -> Result<Uri<String>, ResolveError> {
+        normalizer::normalize(self.into(), true)
     }
 }
 

--- a/tests/checked_normalize.rs
+++ b/tests/checked_normalize.rs
@@ -1,0 +1,125 @@
+#[cfg(feature = "net")]
+use core::net::{Ipv4Addr, Ipv6Addr};
+
+#[cfg(feature = "net")]
+use fluent_uri::component::Host;
+
+use fluent_uri::Uri;
+use fluent_uri::error::ResolveErrorKind;
+
+
+#[test]
+fn normalize() {
+    // Example from Section 6.2 of RFC 3986.
+    let u = Uri::parse("eXAMPLE://a/./b/../b/%63/%7bfoo%7d").unwrap();
+    assert_eq!(u.checked_normalize().unwrap(), "example://a/b/c/%7Bfoo%7D");
+
+    // Lowercase percent-encoded octet.
+    let u = Uri::parse("%3a").unwrap();
+    assert_eq!(u.checked_normalize().unwrap(), "%3A");
+
+    // Uppercase letters in scheme and registered name.
+    let u = Uri::parse("HTTP://www.EXAMPLE.com/").unwrap();
+    assert_eq!(u.checked_normalize().unwrap(), "http://www.example.com/");
+
+    // Empty port.
+    let u = Uri::parse("http://example.com:/").unwrap();
+    assert_eq!(u.checked_normalize().unwrap(), "http://example.com/");
+
+    // Underflow in path resolution.
+    let u = Uri::parse("http://a/../../../g").unwrap();
+    assert!(matches!(u.checked_normalize().unwrap_err().0, ResolveErrorKind::PathUnderflow));
+
+    // Percent-encoded dot segments.
+    let u = Uri::parse("http://a/b/c/%2E/%2E./%2e%2E/d").unwrap();
+    assert_eq!(u.checked_normalize().unwrap(), "http://a/d");
+
+    // Don't remove dot segments from relative reference or rootless path.
+    let u = Uri::parse("foo/../bar").unwrap();
+    assert_eq!(u.checked_normalize().unwrap(), "foo/../bar");
+
+    let u = Uri::parse("/foo/../bar").unwrap();
+    assert_eq!(u.checked_normalize().unwrap(), "/foo/../bar");
+
+    let u = Uri::parse("foo:bar/../baz").unwrap();
+    assert_eq!(u.checked_normalize().unwrap(), "foo:bar/../baz");
+
+    // Do remove dot segments for a URI with absolute path.
+    let u = Uri::parse("foo:/bar/./../baz").unwrap();
+    assert_eq!(u.checked_normalize().unwrap(), "foo:/baz");
+
+    // However, make sure that the output is a valid URI reference.
+    let u = Uri::parse("foo:/.//@@").unwrap();
+    assert_eq!(u.checked_normalize().unwrap(), "foo:/.//@@");
+
+    // Percent-encoded uppercase letters in registered name.
+    let u = Uri::parse("HTTP://%45XAMPLE.%43Om").unwrap();
+    assert_eq!(u.checked_normalize().unwrap(), "http://example.com");
+
+    // Percent-encoded unreserved characters.
+    let u = Uri::parse("%41%42%43%44%45%46%47%48%49%4A%4B%4C%4D%4E%4F%50%51%52%53%54%55%56%57%58%59%5A%61%62%63%64%65%66%67%68%69%6A%6B%6C%6D%6E%6F%70%71%72%73%74%75%76%77%78%79%7A%30%31%32%33%34%35%36%37%38%39%2D%2E%5F%7E").unwrap();
+    assert_eq!(
+        u.checked_normalize().unwrap(),
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+    );
+
+    // Percent-encoded reserved characters.
+    let u = Uri::parse("%3A%2F%3F%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D%25").unwrap();
+    assert_eq!(u.checked_normalize().unwrap(), u);
+
+    // Builder example.
+    let u = Uri::parse("foo://user@example.com:8042/over/there?name=ferret#nose").unwrap();
+    assert_eq!(u.checked_normalize().unwrap(), u);
+
+    // Normalization in all components.
+    let u = Uri::parse("FOO://%55se%72@EXamp%4ce%2ecom:8042/%4b%2f?%4c%2b#%24%4d").unwrap();
+    assert_eq!(u.checked_normalize().unwrap(), "foo://User@example.com:8042/K%2F?L%2B#%24M");
+
+    // Normal IPv4 address.
+    let u = Uri::parse("//127.0.0.1").unwrap();
+    assert_eq!(u.checked_normalize().unwrap(), "//127.0.0.1");
+    #[cfg(feature = "net")]
+    assert!(matches!(
+        u.checked_normalize().unwrap().authority().unwrap().host_parsed(),
+        Host::Ipv4(Ipv4Addr::LOCALHOST)
+    ));
+
+    // Percent-encoded IPv4 address.
+    let u = Uri::parse("//127.0.0.%31").unwrap();
+    assert_eq!(u.checked_normalize().unwrap(), "//127.0.0.1");
+    #[cfg(feature = "net")]
+    assert!(matches!(
+        u.checked_normalize().unwrap().authority().unwrap().host_parsed(),
+        Host::Ipv4(Ipv4Addr::LOCALHOST)
+    ));
+
+    // Normal IPv6 address.
+    let u = Uri::parse("//[::1]").unwrap();
+    assert_eq!(u.checked_normalize().unwrap(), "//[::1]");
+    #[cfg(feature = "net")]
+    assert!(matches!(
+        u.checked_normalize().unwrap().authority().unwrap().host_parsed(),
+        Host::Ipv6(Ipv6Addr::LOCALHOST)
+    ));
+
+    // Verbose IPv6 address.
+    let u = Uri::parse("//[0000:0000:0000::1]").unwrap();
+    assert_eq!(u.checked_normalize().unwrap(), "//[::1]");
+    #[cfg(feature = "net")]
+    assert!(matches!(
+        u.checked_normalize().unwrap().authority().unwrap().host_parsed(),
+        Host::Ipv6(Ipv6Addr::LOCALHOST)
+    ));
+
+    // IPv4-mapped IPv6 address.
+    let u = Uri::parse("//[0:0:0:0:0:ffff:192.0.2.1]").unwrap();
+    assert_eq!(u.checked_normalize().unwrap(), "//[::ffff:192.0.2.1]");
+
+    // Deprecated IPv4-compatible IPv6 address.
+    let u = Uri::parse("//[::192.0.2.1]").unwrap();
+    assert_eq!(u.checked_normalize().unwrap(), "//[::c000:201]");
+
+    // IPvFuture address.
+    let u = Uri::parse("//[v1FdE.AddR]").unwrap();
+    assert_eq!(u.checked_normalize().unwrap(), "//[v1fde.addr]");
+}

--- a/tests/checked_resolve.rs
+++ b/tests/checked_resolve.rs
@@ -1,0 +1,100 @@
+use fluent_uri::Uri;
+
+trait Test {
+    fn pass(&self, r: &str, res: &str);
+    fn fail(&self, r: &str, msg: &str);
+}
+
+impl Test for Uri<&str> {
+    fn pass(&self, r: &str, res: &str) {
+        assert_eq!(Uri::parse(r).unwrap().checked_resolve(self).unwrap(), res)
+    }
+
+    fn fail(&self, r: &str, msg: &str) {
+        let e = Uri::parse(r).unwrap().checked_resolve(self).unwrap_err();
+        assert_eq!(e.to_string(), msg);
+    }
+}
+
+#[test]
+fn checked_resolve() {
+    // Examples from Section 5.4 of RFC 3986.
+    let base = Uri::parse("http://a/b/c/d;p?q").unwrap();
+
+    base.pass("g:h", "g:h");
+    base.pass("g", "http://a/b/c/g");
+    base.pass("./g", "http://a/b/c/g");
+    base.pass("g/", "http://a/b/c/g/");
+    base.pass("/g", "http://a/g");
+    base.pass("//g", "http://g");
+    base.pass("?y", "http://a/b/c/d;p?y");
+    base.pass("g?y", "http://a/b/c/g?y");
+    base.pass("#s", "http://a/b/c/d;p?q#s");
+    base.pass("g#s", "http://a/b/c/g#s");
+    base.pass("g?y#s", "http://a/b/c/g?y#s");
+    base.pass(";x", "http://a/b/c/;x");
+    base.pass("g;x", "http://a/b/c/g;x");
+    base.pass("g;x?y#s", "http://a/b/c/g;x?y#s");
+    base.pass("", "http://a/b/c/d;p?q");
+    base.pass(".", "http://a/b/c/");
+    base.pass("./", "http://a/b/c/");
+    base.pass("..", "http://a/b/");
+    base.pass("../", "http://a/b/");
+    base.pass("../g", "http://a/b/g");
+    base.pass("../..", "http://a/");
+    base.pass("../../", "http://a/");
+    base.pass("../../g", "http://a/g");
+
+    base.pass("/./g", "http://a/g");
+    base.pass("g.", "http://a/b/c/g.");
+    base.pass(".g", "http://a/b/c/.g");
+    base.pass("g..", "http://a/b/c/g..");
+    base.pass("..g", "http://a/b/c/..g");
+
+    base.pass("./../g", "http://a/b/g");
+    base.pass("./g/.", "http://a/b/c/g/");
+    base.pass("g/./h", "http://a/b/c/g/h");
+    base.pass("g/../h", "http://a/b/c/h");
+    base.pass("g;x=1/./y", "http://a/b/c/g;x=1/y");
+    base.pass("g;x=1/../y", "http://a/b/c/y");
+
+    base.pass("g?y/./x", "http://a/b/c/g?y/./x");
+    base.pass("g?y/../x", "http://a/b/c/g?y/../x");
+    base.pass("g#s/./x", "http://a/b/c/g#s/./x");
+    base.pass("g#s/../x", "http://a/b/c/g#s/../x");
+
+    base.pass("http:g", "http:g");
+
+    // Non-hierarchical base URI.
+    let base = Uri::parse("foo:bar").unwrap();
+
+    base.pass("", "foo:bar");
+    base.pass("#baz", "foo:bar#baz");
+    base.pass("http://example.com/", "http://example.com/");
+    base.pass("foo:baz", "foo:baz");
+    base.pass("bar:baz", "bar:baz");
+}
+
+#[test]
+fn checked_resolve_error() {
+    let base = Uri::parse("http://example.com/#title1").unwrap();
+    base.fail("foo", "non-absolute base URI");
+
+    let base = Uri::parse("path/to/file").unwrap();
+    base.fail("foo", "non-absolute base URI");
+
+    let base = Uri::parse("foo:bar").unwrap();
+    base.fail(
+        "baz",
+        "resolving non-same-document relative reference against non-hierarchical base URI",
+    );
+    base.fail(
+        "?baz",
+        "resolving non-same-document relative reference against non-hierarchical base URI",
+    );
+
+    let base = Uri::parse("http://a/b/c/d;p?q").unwrap();
+    base.fail("../../../g", "resolve underflow");
+    base.fail("../../../../g", "resolve underflow");
+    base.fail("/../g", "resolve underflow");
+}

--- a/tests/checked_resolve.rs
+++ b/tests/checked_resolve.rs
@@ -7,11 +7,11 @@ trait Test {
 
 impl Test for Uri<&str> {
     fn pass(&self, r: &str, res: &str) {
-        assert_eq!(Uri::parse(r).unwrap().checked_resolve(self).unwrap(), res)
+        assert_eq!(Uri::parse(r).unwrap().checked_resolve_against(self).unwrap(), res)
     }
 
     fn fail(&self, r: &str, msg: &str) {
-        let e = Uri::parse(r).unwrap().checked_resolve(self).unwrap_err();
+        let e = Uri::parse(r).unwrap().checked_resolve_against(self).unwrap_err();
         assert_eq!(e.to_string(), msg);
     }
 }


### PR DESCRIPTION
Implementation notes:

* Error kind is important for distinguish outside library, which exact error has been occurred. Checking a formatted message is not an option as it's non-stable as it possibly could be.
* Error message is quite dummy at the moment of implementation as it's the least important for me.