### PR TITLE
Add `Resolver`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -80,12 +80,24 @@ impl std::error::Error for BuildError {}
 pub(crate) enum ResolveErrorKind {
     NonAbsoluteBase,
     NonHierarchicalBase,
-    // PathUnderflow,
+    PathUnderflow,
 }
 
 /// An error occurred when resolving URI references.
 #[derive(Clone, Copy, Debug)]
 pub struct ResolveError(pub(crate) ResolveErrorKind);
+
+impl ResolveError {
+    /// Checks whether an underflow in path resolution caused the error.
+    ///
+    /// See [`Resolver::no_path_underflow`] for more details.
+    ///
+    /// [`Resolver::no_path_underflow`]: crate::Resolver::no_path_underflow
+    #[must_use]
+    pub fn is_path_underflow(&self) -> bool {
+        matches!(self.0, ResolveErrorKind::PathUnderflow)
+    }
+}
 
 #[cfg(feature = "std")]
 impl std::error::Error for ResolveError {}

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -77,6 +77,7 @@ impl Display for ResolveError {
             ResolveErrorKind::NonHierarchicalBase => {
                 "resolving non-same-document relative reference against non-hierarchical base URI"
             }
+            ResolveErrorKind::PathUnderflow => "underflow in path resolution",
         };
         f.write_str(msg)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
     clippy::if_not_else,
     clippy::ignored_unit_patterns,
     clippy::map_unwrap_or,
-    clippy::missing_errors_doc,
+    // clippy::missing_errors_doc,
     clippy::must_use_candidate,
     // clippy::redundant_closure_for_method_calls,
     clippy::semicolon_if_nothing_returned,
@@ -66,6 +66,7 @@ mod parser;
 mod resolver;
 
 pub use builder::Builder;
+pub use resolver::Resolver;
 
 #[cfg(feature = "std")]
 extern crate std;
@@ -445,14 +446,17 @@ impl<'i, 'o, T: BorrowOrShare<'i, 'o, str>> Uri<T> {
     /// No normalization except the removal of dot segments will be performed.
     /// Use [`normalize`] if necessary.
     ///
-    /// [absolute URI]: Self::is_absolute_uri
-    /// [rootless]: EStr::<Path>::is_rootless
-    /// [`normalize`]: Self::normalize
-    ///
     /// This method has the property that
     /// `self.resolve_against(base).unwrap().normalize()` equals
     /// `self.normalize().resolve_against(&base.normalize()).unwrap()`
     /// when no panic occurs.
+    ///
+    /// If you need to resolve multiple references against a common base URI,
+    /// consider using [`Resolver`] instead.
+    ///
+    /// [absolute URI]: Self::is_absolute_uri
+    /// [rootless]: EStr::<Path>::is_rootless
+    /// [`normalize`]: Self::normalize
     ///
     /// # Errors
     ///
@@ -471,7 +475,7 @@ impl<'i, 'o, T: BorrowOrShare<'i, 'o, str>> Uri<T> {
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     pub fn resolve_against<U: Bos<str>>(&self, base: &Uri<U>) -> Result<Uri<String>, ResolveError> {
-        resolver::resolve(base.as_ref(), self.as_ref())
+        resolver::resolve(base.as_ref(), self.as_ref(), false)
     }
 
     /// Normalizes the URI reference.

--- a/src/normalizer.rs
+++ b/src/normalizer.rs
@@ -16,7 +16,7 @@ pub(crate) fn normalize(u: Uri<&str>) -> Uri<String> {
 
     if u.has_scheme() && path.starts_with('/') {
         normalize_estr(&mut buf, path, false);
-        resolver::remove_dot_segments(&mut path_buf, &buf);
+        resolver::remove_dot_segments(&mut path_buf, &buf, false).unwrap();
         buf.clear();
     } else {
         // Don't remove dot segments from relative reference or rootless path.

--- a/tests/resolve.rs
+++ b/tests/resolve.rs
@@ -1,4 +1,4 @@
-use fluent_uri::Uri;
+use fluent_uri::{Resolver, Uri};
 
 trait Test {
     fn pass(&self, r: &str, res: &str);
@@ -111,4 +111,19 @@ fn resolve_error() {
         "?baz",
         "resolving non-same-document relative reference against non-hierarchical base URI",
     );
+
+    let resolver =
+        Resolver::with_base(Uri::parse("http://a/b/c/d;p?q").unwrap()).no_path_underflow();
+    assert!(resolver
+        .resolve(&Uri::parse("../../../g").unwrap())
+        .unwrap_err()
+        .is_path_underflow());
+    assert!(resolver
+        .resolve(&Uri::parse("../../../../g").unwrap())
+        .unwrap_err()
+        .is_path_underflow());
+    assert!(resolver
+        .resolve(&Uri::parse("/../g").unwrap())
+        .unwrap_err()
+        .is_path_underflow());
 }


### PR DESCRIPTION
This patch adds a `Resolver` struct which is a configurable URI reference resolver against a fixed base URI. Users can configure a resolver to disallow underflows in path resolution by calling `Resolver::no_path_underflow`. Underflows can be detected by calling `ResolveError::is_path_underflow`.