### PR TITLE
Remove path underflow as not planned

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -80,7 +80,6 @@ impl std::error::Error for BuildError {}
 pub(crate) enum ResolveErrorKind {
     InvalidBase,
     OpaqueBase,
-    // PathUnderflow,
 }
 
 /// An error occurred when resolving URI references.


### PR DESCRIPTION
for reference: https://github.com/yescallop/fluent-uri-rs/issues/17