### PR TITLE
chore: use core::error::Error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -57,8 +57,7 @@ impl<I: AsRef<str>> ParseError<I> {
     }
 }
 
-#[cfg(feature = "std")]
-impl<I> std::error::Error for ParseError<I> {}
+impl<I> core::error::Error for ParseError<I> {}
 
 /// Detailed cause of a [`BuildError`].
 #[derive(Clone, Copy, Debug)]
@@ -72,8 +71,7 @@ pub(crate) enum BuildErrorKind {
 #[derive(Clone, Copy, Debug)]
 pub struct BuildError(pub(crate) BuildErrorKind);
 
-#[cfg(feature = "std")]
-impl std::error::Error for BuildError {}
+impl core::error::Error for BuildError {}
 
 /// Detailed cause of a [`ResolveError`].
 #[derive(Clone, Copy, Debug)]
@@ -87,5 +85,4 @@ pub(crate) enum ResolveErrorKind {
 #[derive(Clone, Copy, Debug)]
 pub struct ResolveError(pub(crate) ResolveErrorKind);
 
-#[cfg(feature = "std")]
-impl std::error::Error for ResolveError {}
+impl core::error::Error for ResolveError {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@
 //!
 //! [`Host`]: component::Host
 //! [`Authority::socket_addrs`]: component::Authority::socket_addrs
-//! [`Error`]: std::error::Error
+//! [`Error`]: core::error::Error
 //! [`Serialize`]: serde::Serialize
 //! [`Deserialize`]: serde::Deserialize
 


### PR DESCRIPTION
enables `core::error::Error` by default. No longer gated behind `#[cfg(feature = "std")]`

https://blog.rust-lang.org/2024/09/05/Rust-1.81.0/#core-error-error