### PR TITLE
feat: implement equality operators on ParseError

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,7 @@
 use crate::internal::NoInput;
 
 /// Detailed cause of a [`ParseError`].
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum ParseErrorKind {
     /// Invalid percent-encoded octet that is either non-hexadecimal or incomplete.
     ///
@@ -22,7 +22,7 @@ pub(crate) enum ParseErrorKind {
 }
 
 /// An error occurred when parsing a URI/IRI (reference).
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Eq, PartialEq)]
 pub struct ParseError<I = NoInput> {
     pub(crate) index: usize,
     pub(crate) kind: ParseErrorKind,

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -16,6 +16,7 @@ pub trait Value: Default {}
 impl Value for &str {}
 impl Value for String {}
 
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub struct NoInput;
 
 pub struct Criteria {


### PR DESCRIPTION
slight quality of life improvement for people writing unit tests that involved `ParseError`s. They no longer need to use `assert!(matches!())` and can use `assert_eq!()`