### PR TITLE
Add configurable `Resolver`

### DIFF
--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -76,6 +76,7 @@ impl Display for ResolveError {
             Self::InvalidReferenceAgainstOpaqueBase => {
                 "when base has no authority and its path is rootless, reference should either have scheme, be empty or start with '#'"
             }
+            Self::PathUnderflow => "underflow occurred in path resolution",
         };
         f.write_str(msg)
     }

--- a/src/normalize.rs
+++ b/src/normalize.rs
@@ -1,5 +1,5 @@
 use crate::{
-    imp::{HostMeta, Meta, Ref},
+    imp::{HostMeta, Meta, RmrRef},
     parse,
     pct_enc::{
         decode_octet, encode_byte, next_code_point,
@@ -11,7 +11,7 @@ use crate::{
 use alloc::{string::String, vec::Vec};
 use core::{fmt::Write, num::NonZeroUsize};
 
-pub(crate) fn normalize(r: Ref<'_, '_>, ascii_only: bool) -> (String, Meta) {
+pub(crate) fn normalize(r: RmrRef<'_, '_>, ascii_only: bool) -> (String, Meta) {
     // For "a://[::ffff:5:9]/" the capacity is not enough,
     // but it's fine since this rarely happens.
     let mut buf = String::with_capacity(r.as_str().len());
@@ -21,7 +21,7 @@ pub(crate) fn normalize(r: Ref<'_, '_>, ascii_only: bool) -> (String, Meta) {
 
     if r.has_scheme() && path.starts_with('/') {
         normalize_estr(&mut buf, path, false, ascii_only, false);
-        resolve::remove_dot_segments(&mut path_buf, &buf);
+        resolve::remove_dot_segments(&mut path_buf, &buf, true).unwrap();
         buf.clear();
     } else {
         // Don't remove dot segments from relative reference or rootless path.


### PR DESCRIPTION
This patch adds a `Resolver` struct which is a configurable URI/IRI reference resolver against a fixed base. Users can configure whether to allow underflow in path resolution by calling `Resolver::allow_path_underflow`. Underflow is indicated by the exposed error enum variant `ResolveError::Underflow`.

Cc @eirnym for review. I've added you as a coauthor of the commit.

Closes #17.