### PR TITLE
add parse_lax function

### DIFF
--- a/src/imp.rs
+++ b/src/imp.rs
@@ -71,6 +71,7 @@ pub trait Parse {
     type Err;
 
     fn parse<R: RiMaybeRef<Val = Self::Val>>(self) -> Result<R, Self::Err>;
+    fn parse_lax<R: RiMaybeRef<Val = Self::Val>>(self) -> Result<R, Self::Err>;
 }
 
 impl<'a> Parse for &'a str {
@@ -78,7 +79,10 @@ impl<'a> Parse for &'a str {
     type Err = ParseError;
 
     fn parse<R: RiMaybeRef<Val = Self::Val>>(self) -> Result<R, Self::Err> {
-        parse::parse(self.as_bytes(), R::CONSTRAINTS).map(|meta| R::new(self, meta))
+        parse::parse(self.as_bytes(), R::CONSTRAINTS, false).map(|meta| R::new(self, meta))
+    }
+    fn parse_lax<R: RiMaybeRef<Val = Self::Val>>(self) -> Result<R, Self::Err> {
+        parse::parse(self.as_bytes(), R::CONSTRAINTS, true).map(|meta| R::new(self, meta))
     }
 }
 
@@ -87,7 +91,13 @@ impl Parse for String {
     type Err = (ParseError, Self);
 
     fn parse<R: RiMaybeRef<Val = Self::Val>>(self) -> Result<R, Self::Err> {
-        match parse::parse(self.as_bytes(), R::CONSTRAINTS) {
+        match parse::parse(self.as_bytes(), R::CONSTRAINTS, false) {
+            Ok(meta) => Ok(R::new(self, meta)),
+            Err(e) => Err((e, self)),
+        }
+    }
+    fn parse_lax<R: RiMaybeRef<Val = Self::Val>>(self) -> Result<R, Self::Err> {
+        match parse::parse(self.as_bytes(), R::CONSTRAINTS, true) {
             Ok(meta) => Ok(R::new(self, meta)),
             Err(e) => Err((e, self)),
         }
@@ -316,6 +326,19 @@ macro_rules! ri_maybe_ref {
                 I: Parse<Val = T>,
             {
                 input.parse()
+            }
+            ///
+            /// # Errors
+            ///
+            /// Returns `Err` if the string does not match the
+            #[doc = concat!("[`", $abnf, "`][abnf] ABNF rule from RFC ", $rfc, ".")]
+            ///
+            #[doc = concat!("[abnf]: ", $abnf_link)]
+            pub fn parse_lax<I>(input: I) -> Result<Self, I::Err>
+            where
+                I: Parse<Val = T>,
+            {
+                input.parse_lax()
             }
         }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -58,13 +58,13 @@ macro_rules! err {
     };
 }
 
-pub(crate) fn parse(bytes: &[u8], constraints: Constraints) -> Result<Meta> {
+pub(crate) fn parse(bytes: &[u8], constraints: Constraints, lax: bool) -> Result<Meta> {
     let mut parser = Parser {
         constraints,
         reader: Reader::new(bytes),
         out: Meta::default(),
     };
-    parser.parse_from_scheme()?;
+    parser.parse_from_scheme(lax)?;
     Ok(parser.out)
 }
 
@@ -439,7 +439,7 @@ impl Parser<'_> {
         }
     }
 
-    fn parse_from_scheme(&mut self) -> Result<()> {
+    fn parse_from_scheme(&mut self, lax: bool) -> Result<()> {
         self.read::<Scheme>()?;
 
         if self.peek(0) == Some(b':') {
@@ -453,23 +453,23 @@ impl Parser<'_> {
             // INVARIANT: Skipping ":" is fine.
             self.skip(1);
             return if self.read_str("//") {
-                self.parse_from_authority()
+                self.parse_from_authority(lax)
             } else {
-                self.parse_from_path(PathKind::General)
+                self.parse_from_path(PathKind::General, lax)
             };
         } else if self.constraints.scheme_required {
             err!(self.pos, UnexpectedCharOrEnd);
         } else if self.pos == 0 {
             // Nothing read.
             if self.read_str("//") {
-                return self.parse_from_authority();
+                return self.parse_from_authority(lax);
             }
         }
         // Scheme chars are valid for path.
-        self.parse_from_path(PathKind::ContinuedNoScheme)
+        self.parse_from_path(PathKind::ContinuedNoScheme, lax)
     }
 
-    fn parse_from_authority(&mut self) -> Result<()> {
+    fn parse_from_authority(&mut self, lax: bool) -> Result<()> {
         // We first try to read host and port, noting that
         // a reg-name or IPv4address can also be part of userinfo.
         let host_start = self.pos;
@@ -505,10 +505,10 @@ impl Parser<'_> {
         }
 
         self.out.auth_meta = Some(auth_meta);
-        self.parse_from_path(PathKind::AbEmpty)
+        self.parse_from_path(PathKind::AbEmpty, lax)
     }
 
-    fn parse_from_path(&mut self, kind: PathKind) -> Result<()> {
+    fn parse_from_path(&mut self, kind: PathKind, lax: bool) -> Result<()> {
         let path_start;
 
         match kind {
@@ -541,7 +541,11 @@ impl Parser<'_> {
         }
 
         if self.read_str("#") {
-            self.select_read::<Fragment, IFragment>()?;
+            if lax {
+                self.select_read::<FragmentLax, IFragmentLax>()?;
+            } else {
+                self.select_read::<Fragment, IFragment>()?;
+            }
         }
 
         if self.has_remaining() {

--- a/src/pct_enc/encoder.rs
+++ b/src/pct_enc/encoder.rs
@@ -93,6 +93,14 @@ impl Encoder for Fragment {
     const TABLE: Table = FRAGMENT;
 }
 
+/// An encoder for URI fragment.
+#[derive(Clone, Copy)]
+pub struct FragmentLax(());
+
+impl Encoder for FragmentLax {
+    const TABLE: Table = FRAGMENT_LAX;
+}
+
 /// An encoder for IRI fragment.
 #[derive(Clone, Copy)]
 pub struct IFragment(());
@@ -101,6 +109,13 @@ impl Encoder for IFragment {
     const TABLE: Table = IFRAGMENT;
 }
 
+/// An encoder for IRI fragment. Lax version
+#[derive(Clone, Copy)]
+pub struct IFragmentLax(());
+
+impl Encoder for IFragmentLax {
+    const TABLE: Table = IFRAGMENT_LAX;
+}
 /// An encoder for URI data which preserves only [unreserved] characters
 /// and encodes the others.
 ///

--- a/src/pct_enc/table.rs
+++ b/src/pct_enc/table.rs
@@ -232,6 +232,8 @@ pub const QUERY: Table = PCHAR.or(new(b"/?"));
 /// `fragment = *( pchar / "/" / "?" )`
 pub const FRAGMENT: Table = QUERY;
 
+pub const FRAGMENT_LAX: Table = FRAGMENT.or(new(b"#"));
+
 /// `unreserved = ALPHA / DIGIT / "-" / "." / "_" / "~"`
 pub const UNRESERVED: Table = ALPHA.or(DIGIT).or(new(b"-._~"));
 
@@ -253,3 +255,4 @@ pub const IPATH: Table = PATH.or_ucschar();
 pub const ISEGMENT_NZ_NC: Table = SEGMENT_NZ_NC.or_ucschar();
 pub const IQUERY: Table = QUERY.or_ucschar().or_iprivate();
 pub const IFRAGMENT: Table = FRAGMENT.or_ucschar();
+pub const IFRAGMENT_LAX: Table = FRAGMENT_LAX.or_ucschar();

--- a/tests/parse.rs
+++ b/tests/parse.rs
@@ -237,6 +237,14 @@ fn parse_relative() {
     assert_eq!(r.fragment(), Some(EStr::new_or_panic("fragment")));
 }
 
+#[test]
+fn parse_tolerance() {
+    let r = Uri::parse_lax("term://~/code/typos-lsp//59317:/bin/zsh;#toggleterm#1").unwrap();
+    assert_eq!(r.scheme().as_str(), "term");
+    assert_eq!(r.path().as_str(), "/code/typos-lsp//59317:/bin/zsh;");
+    assert_eq!(r.fragment().unwrap().as_str(), "toggleterm#1");
+}
+
 use ParseErrorKind::*;
 
 #[test]


### PR DESCRIPTION
resolve: https://github.com/yescallop/fluent-uri-rs/issues/42

follow what the author suggested, I add a new function named parse_lax, this part will make some torance for some usage, like # in Fragment. Any thing that is unrelated to the rfc, should be added in this part, this is my plan